### PR TITLE
Add support for Snacks! Continued

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # SETI-Greenhouse
+
+A dedicated greenhouse part for Kerbal Space Program, for use with life support mods (or just as a cosmetic part).
+
+Available at two sizes, 2.5m and 3.75m.
+
+Model by zzz, mod by Yemo.
+

--- a/SETIgreenhouse/Parts/Greenhouse/Greenhouse1.cfg
+++ b/SETIgreenhouse/Parts/Greenhouse/Greenhouse1.cfg
@@ -70,6 +70,8 @@ PART
 
 @PART[SETIgreenhouse1]:NEEDS[ThunderAerospace]
 {
+	%tags = cck-lifesupport
+
 	MODULE
 	{
 		name = TacGenericConverter

--- a/SETIgreenhouse/Parts/Greenhouse/Greenhouse1.cfg
+++ b/SETIgreenhouse/Parts/Greenhouse/Greenhouse1.cfg
@@ -37,6 +37,8 @@ PART
 	manufacturer = Space Exploration & Technology Initiative
 	description = The 2.5m SETI Greenhouse, made by famous designer zzz, provides for the life support needs of up to 1 kerbal. To do so, it uses the waste products up to 1 kerbal as well as electric charge.
 
+	tags = seti greenhouse food supplies life support snack
+
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,0
 
@@ -70,7 +72,7 @@ PART
 
 @PART[SETIgreenhouse1]:NEEDS[ThunderAerospace]
 {
-	%tags = cck-lifesupport
+	@tags ^= :^:cck-lifesupport :
 
 	MODULE
 	{
@@ -290,6 +292,9 @@ PART
 // We configure SETIgreenhouse1 for 8 kerbals and SETIgreenhouse3 for 24 kerbals. For Snacks! Continued, these much higher numbers are necessary,
 // because out of the box, Snacks! Continued already configures the stock Hitchhiker can to support 4 kerbals, at 1 meal per day and 100% recycler efficiency.
 //
+// Note that this includes the specialist bonus from having a fully trained scientist on board the vessel; with no scientist, the conversion rate is reduced
+// to 0.9 times its nominal value.
+//
 // Since the Hitchhiker is primarily a crew cabin, where the recycler is a secondary functionality, the dedicated greenhouses need higher recycler capacities
 // in order to make it sensible to use them.
 //
@@ -311,18 +316,19 @@ PART
 //     - soil capacity 1200 (scaled by ratio of #supported-kerbals)
 //     - snacks capacity 600 (scaled from SETIgreenhouse1 by mass ratio)
 //
-// Note that Kerbal Planetary Base Systems provides a planetary greenhouse, which plays a different role: it is a snack generator, similar to how Snacks! Continued configures the stock science lab.
-// It has a much higher production rate and lower ElectricCharge cost than the science lab, presumably because it is a dedicated part, but the science lab has higher ore efficiency.
+// Kerbal Planetary Base Systems provides a planetary greenhouse, which plays a different role: it is a snack generator, similar to how Snacks! Continued configures the stock science lab.
+// It has a much higher production rate and lower ElectricCharge cost than the science lab, presumably because it is a dedicated part, but the science lab has higher ore efficiency, as follows:
 //
-// Details:
-//     - KPBS greenhouse: 0.5 Ore into 1 Snacks using 3 EC (1 Ore = 2 Snacks)
-//     - science lab: 0.002 Ore into 0.01 Snacks using 30 EC (1 Ore = 5 Snacks)
+// - KPBS greenhouse: 0.5 Ore into 1 Snacks using 3 EC (1 Ore = 2 Snacks)
+// - science lab: 0.002 Ore into 0.01 Snacks using 30 EC (1 Ore = 5 Snacks)
+//
+// SETI-Greenhouse does not provide a snack generator, since in orbit, a recycler is more useful.
 
 // The technical details of this config are based on the recycler config provided with Snacks! Continued.
 //
 @PART[SETIgreenhouse1]:NEEDS[SETIgreenhouse,Snacks]:AFTER[Snacks]
 {
-	%tags = cck-lifesupport
+	@tags ^= :^:cck-lifesupport :
 
 	%description = The 2.5m SETI Greenhouse, made by famous designer zzz, provides for the life support needs of up to 8 kerbals. To do so, it uses the waste products up to 8 kerbals as well as electric charge.
 

--- a/SETIgreenhouse/Parts/Greenhouse/Greenhouse1.cfg
+++ b/SETIgreenhouse/Parts/Greenhouse/Greenhouse1.cfg
@@ -282,3 +282,105 @@ PART
 		maxAmount = 1600
 	}
 }
+
+//------\\
+//---Snacks! Continued
+//------\\
+
+// We configure SETIgreenhouse1 for 8 kerbals and SETIgreenhouse3 for 24 kerbals. For Snacks! Continued, these much higher numbers are necessary,
+// because out of the box, Snacks! Continued already configures the stock Hitchhiker can to support 4 kerbals, at 1 meal per day and 100% recycler efficiency.
+//
+// Since the Hitchhiker is primarily a crew cabin, where the recycler is a secondary functionality, the dedicated greenhouses need higher recycler capacities
+// in order to make it sensible to use them.
+//
+// Balancing considerations:
+//
+// - stock hitchhiker can:
+//     - crew capacity 4, weight 2.5, maxTemp = 1000, skinMaxTemp = 2000
+//     - supports 4 kerbals at 1 meal per day, 100% recycler efficiency
+//     - soil capacity 200 (special-cased)
+//     - snacks capacity #seats * 200 = 4 * 200 = 800 (general rule, crew part with no command module)
+// - SETIgreenhouse1
+//     - crew capacity 0, weight 2.0, maxTemp = 1200, no separate skinMaxTemp
+//     - supports 8 kerbals (can still be lighter than the hitchhiker, by stripping out all other components, leaving only the recycler stuff)
+//     - soil capacity 400 (scaled from hitchhiker can by ratio of #supported-kerbals)
+//     - snacks capacity 200 (not much storage space left over in the greenhouse, but we should probably have some snack storage to stay within the as-few-extra-parts-as-possible design goal of Snacks!)
+// - SETIgreenhouse3
+//     - crew capacity 0, weight 6.0, maxTemp = 1200, no separate skinMaxTemp
+//     - supports 24 kerbals (scaled from SETIgreenhouse1 by mass ratio; this is also near the volume ratio (3.75 / 2.5)**3 ~ 3.375)
+//     - soil capacity 1200 (scaled by ratio of #supported-kerbals)
+//     - snacks capacity 600 (scaled from SETIgreenhouse1 by mass ratio)
+//
+// Note that Kerbal Planetary Base Systems provides a planetary greenhouse, which plays a different role: it is a snack generator, similar to how Snacks! Continued configures the stock science lab.
+// It has a much higher production rate and lower ElectricCharge cost than the science lab, presumably because it is a dedicated part, but the science lab has higher ore efficiency.
+//
+// Details:
+//     - KPBS greenhouse: 0.5 Ore into 1 Snacks using 3 EC (1 Ore = 2 Snacks)
+//     - science lab: 0.002 Ore into 0.01 Snacks using 30 EC (1 Ore = 5 Snacks)
+
+// The technical details of this config are based on the recycler config provided with Snacks! Continued.
+//
+@PART[SETIgreenhouse1]:NEEDS[SETIgreenhouse,Snacks]:AFTER[Snacks]
+{
+	%tags = cck-lifesupport
+
+	%description = The 2.5m SETI Greenhouse, made by famous designer zzz, provides for the life support needs of up to 8 kerbals. To do so, it uses the waste products up to 8 kerbals as well as electric charge.
+
+	//This is calibrated for 6 kerbals at 100% efficiency when then consume
+	//1 snack per meal and 1 meal per day.
+	//In game, the player can adjust the efficiency of the recycler from 10% to 100%.
+	//Given the dynamic nature, the input/output ratio is ALWAYS set to 0.00004630,
+	//which gives a daily input/output of 1.00008 per day. The recycler will then adjust
+	//the input/output ratio based upon RecyclerCapacity and recycler efficiency.
+	MODULE
+	{
+		name = SoilRecycler
+		ConverterName = Soil Recycler
+		StartActionName = Start Soil Recycler
+		StopActionName = Stop Soil Recycler
+		AutoShutdown = false
+		GeneratesHeat = false
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		UseSpecializationBonus = true
+		SpecialistEfficiencyFactor = 0.1
+		ExperienceEffect = ScienceSkill
+		EfficiencyBonus = 1.0
+		RecyclerCapacity = 8
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Soil
+			Ratio = 0.000034723
+			FlowMode = ALL_VESSEL
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 12
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Snacks
+			Ratio = 0.000034723
+			DumpExcess = false
+			FlowMode = ALL_VESSEL
+		}
+	}
+
+	RESOURCE
+	{
+		name = Soil
+		amount = 0
+		maxAmount = 400
+	}
+
+	RESOURCE
+	{
+		name = Snacks
+		amount = 0
+		maxAmount = 200
+	}
+}

--- a/SETIgreenhouse/Parts/Greenhouse/Greenhouse3.cfg
+++ b/SETIgreenhouse/Parts/Greenhouse/Greenhouse3.cfg
@@ -38,6 +38,8 @@ PART
 	manufacturer = Space Exploration & Technology Initiative
 	description =  The large 3.75m SETI Greenhouse, made by famous designer zzz, provides for the life support needs of up to 3 kerbals. To do so, it uses the waste products up to 3 kerbals as well as electric charge.
 
+	tags = seti greenhouse food supplies life support snack
+
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,0
 
@@ -71,7 +73,7 @@ PART
 
 @PART[SETIgreenhouse3]:NEEDS[ThunderAerospace]
 {
-	%tags = cck-lifesupport
+	@tags ^= :^:cck-lifesupport :
 
 	MODULE
 	{
@@ -292,7 +294,7 @@ PART
 
 @PART[SETIgreenhouse3]:NEEDS[SETIgreenhouse,Snacks]:AFTER[Snacks]
 {
-	%tags = cck-lifesupport
+	@tags ^= :^:cck-lifesupport :
 
 	%description = The large 3.75m SETI Greenhouse, made by famous designer zzz, provides for the life support needs of up to 24 kerbals. To do so, it uses the waste products up to 24 kerbals as well as electric charge.
 

--- a/SETIgreenhouse/Parts/Greenhouse/Greenhouse3.cfg
+++ b/SETIgreenhouse/Parts/Greenhouse/Greenhouse3.cfg
@@ -283,3 +283,74 @@ PART
 		maxAmount = 4800
 	}
 }
+
+//------\\
+//---Snacks! Continued
+//------\\
+
+// See Greenhouse1.cfg for explanation and balancing considerations for both greenhouses.
+
+@PART[SETIgreenhouse3]:NEEDS[SETIgreenhouse,Snacks]:AFTER[Snacks]
+{
+	%tags = cck-lifesupport
+
+	%description = The large 3.75m SETI Greenhouse, made by famous designer zzz, provides for the life support needs of up to 24 kerbals. To do so, it uses the waste products up to 24 kerbals as well as electric charge.
+
+	//This is calibrated for 24 kerbals at 100% efficiency when then consume
+	//1 snack per meal and 1 meal per day.
+	//In game, the player can adjust the efficiency of the recycler from 10% to 100%.
+	//Given the dynamic nature, the input/output ratio is ALWAYS set to 0.00004630,
+	//which gives a daily input/output of 1.00008 per day. The recycler will then adjust
+	//the input/output ratio based upon RecyclerCapacity and recycler efficiency.
+	MODULE
+	{
+		name = SoilRecycler
+		ConverterName = Soil Recycler
+		StartActionName = Start Soil Recycler
+		StopActionName = Stop Soil Recycler
+		AutoShutdown = false
+		GeneratesHeat = false
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		UseSpecializationBonus = true
+		SpecialistEfficiencyFactor = 0.1
+		ExperienceEffect = ScienceSkill
+		EfficiencyBonus = 1.0
+		RecyclerCapacity = 24
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Soil
+			Ratio = 0.000034723
+			FlowMode = ALL_VESSEL
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 12
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Snacks
+			Ratio = 0.000034723
+			DumpExcess = false
+			FlowMode = ALL_VESSEL
+		}
+	}
+
+	RESOURCE
+	{
+		name = Soil
+		amount = 0
+		maxAmount = 1200
+	}
+
+	RESOURCE
+	{
+		name = Snacks
+		amount = 0
+		maxAmount = 600
+	}
+}

--- a/SETIgreenhouse/Parts/Greenhouse/Greenhouse3.cfg
+++ b/SETIgreenhouse/Parts/Greenhouse/Greenhouse3.cfg
@@ -71,6 +71,8 @@ PART
 
 @PART[SETIgreenhouse3]:NEEDS[ThunderAerospace]
 {
+	%tags = cck-lifesupport
+
 	MODULE
 	{
 		name = TacGenericConverter


### PR DESCRIPTION
This PR:

- adds support for the Snacks! (Continued) life support mod
- adds the cck-lifesupport tag to support Community Category Kit
- adds tags for searching
- updates README.md on GitHub to explain to passers-by what this project is for

At least on my install, the search seems somehow broken at the moment (KSP 1.3.0); the greenhouses don't show up in the search. However, the same issue is affecting also at least the KPBS mod.

With Filter Extensions and Community Category Kit installed, the greenhouses (including the SETI ones) are correctly listed under the Life Support category.